### PR TITLE
Issue #8: Return prefixes in hook_config_info()

### DIFF
--- a/facetapi.module
+++ b/facetapi.module
@@ -932,6 +932,7 @@ function facetapi_config_info() {
     'label' => t('Module name settings'),
     'group' => t('Configuration'),
   );
+  return $prefixes;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/facetapi/issues/8